### PR TITLE
fix: move copy logic into separate component to avoid shared state

### DIFF
--- a/src/app/(website)/template/[category]/[key]/page.tsx
+++ b/src/app/(website)/template/[category]/[key]/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { useLoadTemplates } from "@/hooks/useLoadTemplates";
 import { Skeleton } from "@/components/ui/skeleton";
+import { CopyButton } from "@/components/form-builder/dialogs/copy-button";
 
 const viewportEditorStyles = {
   sm: "w-[370px]",
@@ -53,7 +54,6 @@ export default function TemplatePage({
   const updateMode = useFormBuilderStore((state) => state.updateMode);
   const { isLoading, error: loadError } = useLoadTemplates();
   const [formattedCode, setFormattedCode] = useState("");
-  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     const template = category;
@@ -87,12 +87,6 @@ export default function TemplatePage({
     };
     generateCode();
   }, [components]);
-
-  const handleCopy = async (text: string) => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
 
   const activeTemplate = loadedTemplate;
 
@@ -170,18 +164,7 @@ export default function TemplatePage({
           <div className="p-0 w-full overflow-y-auto rounded-lg border">
             {components && components.length > 0 ? (
               <div className="relative">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="absolute top-2 right-2 text-muted-foreground"
-                  onClick={() => handleCopy(formattedCode)}
-                >
-                  {copied ? (
-                    <Check className="h-4 w-4" />
-                  ) : (
-                    <Copy className="h-4 w-4" />
-                  )}
-                </Button>
+                <CopyButton content={formattedCode} />
                 <Pre
                   language="tsx"
                   code={formattedCode}

--- a/src/components/form-builder/dialogs/copy-button.tsx
+++ b/src/components/form-builder/dialogs/copy-button.tsx
@@ -1,0 +1,26 @@
+import { Button } from "@/components/ui/button";
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+export const CopyButton = ({ content }: { content: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(content);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="absolute top-2 right-2 text-muted-foreground"
+        onClick={handleCopy}
+      >
+        {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+      </Button>
+    </div>
+  );
+};

--- a/src/components/form-builder/dialogs/generate-code-dialog.tsx
+++ b/src/components/form-builder/dialogs/generate-code-dialog.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { Pre } from "@/components/ui/pre";
-import { Copy, Check } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { generateFormCode } from "../helpers/generate-react-code";
 import { useFormBuilderStore } from "@/stores/form-builder-store";
 import { ReactCode } from "@/types/form-builder.types";
 import { DependenciesImports } from "../helpers/generate-react-code";
+import { CopyButton } from "./copy-button";
 
 const getShadcnInstallInstructions = (
   dependencies: ReactCode["dependencies"]
@@ -45,7 +44,6 @@ export function MainExport() {
     generateCode();
   }, [components]);
 
-  const [copied, setCopied] = useState(false);
   const formTitle = useFormBuilderStore
     .getState()
     .formTitle.replace(/\s+/g, "");
@@ -60,12 +58,6 @@ export function MainExport() {
     a.click();
     window.URL.revokeObjectURL(url);
     document.body.removeChild(a);
-  };
-
-  const handleCopy = async (text: string) => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
   };
 
   const installationInstructions = getShadcnInstallInstructions(
@@ -86,18 +78,7 @@ export function MainExport() {
         <h3 className="text-sm text-muted-foreground">
           Run the following commands to add the required components:
         </h3>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="absolute top-2 right-2 text-muted-foreground"
-          onClick={() => handleCopy(installationInstructions)}
-        >
-          {copied ? (
-            <Check className="h-4 w-4" />
-          ) : (
-            <Copy className="h-4 w-4" />
-          )}
-        </Button>
+        <CopyButton content={installationInstructions} />
         <div className="relative overflow-x-auto rounded-md min-h-20 mt-4">
           <Pre language="bash" code={installationInstructions} />
         </div>
@@ -112,20 +93,7 @@ export function MainExport() {
             Run the following commands to add the required third party
             dependencies:
           </h3>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="absolute top-2 right-2 text-muted-foreground"
-            onClick={() =>
-              handleCopy(thirdPartyDependenciesInstallInstructions)
-            }
-          >
-            {copied ? (
-              <Check className="h-4 w-4" />
-            ) : (
-              <Copy className="h-4 w-4" />
-            )}
-          </Button>
+          <CopyButton content={thirdPartyDependenciesInstallInstructions} />
           <div className="relative overflow-x-auto rounded-md min-h-20 mt-4">
             <Pre
               language="bash"
@@ -145,18 +113,7 @@ export function MainExport() {
           .
         </h3>
 
-        <Button
-          variant="ghost"
-          size="sm"
-          className="absolute top-2 right-2 text-muted-foreground"
-          onClick={() => handleCopy(generatedCode.code)}
-        >
-          {copied ? (
-            <Check className="h-4 w-4" />
-          ) : (
-            <Copy className="h-4 w-4" />
-          )}
-        </Button>
+        <CopyButton content={generatedCode.code} />
       </div>
 
       <div className="flex-1 overflow-y-auto relative">
@@ -168,21 +125,11 @@ export function MainExport() {
         <h3 className="text-sm text-muted-foreground">
           Import the form component and use it in your project.
         </h3>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="absolute top-2 right-2 text-muted-foreground"
-          onClick={() =>
-            handleCopy(`import ${formTitle} from "./${formTitle}";
-<${formTitle} />`)
-          }
-        >
-          {copied ? (
-            <Check className="h-4 w-4" />
-          ) : (
-            <Copy className="h-4 w-4" />
-          )}
-        </Button>
+        <CopyButton
+          content={`import ${formTitle} from "./${formTitle}";
+<${formTitle} />`}
+        />
+
         <div className="relative overflow-auto rounded-md min-h-20 mt-4">
           <Pre
             language="typescript"


### PR DESCRIPTION
This PR fixes an issue where all copy buttons were sharing the same `copied` state.
The copy button logic has been moved into a separate component so each button now manages its own state independently.

This prevents all buttons from toggling when one is clicked and ensures correct UI behavior.

### Before : 

https://github.com/user-attachments/assets/584d3c1f-6415-41e4-aa38-0413b7352613

### After : 

https://github.com/user-attachments/assets/1150b771-072e-45f1-bb5a-78b5dd1f850e




